### PR TITLE
deb_setup fix for various version numbers.

### DIFF
--- a/deb_setup.sh
+++ b/deb_setup.sh
@@ -7,10 +7,10 @@ if test $PG_SLOP -z; then
   sudo mkdir -p /opt/postgres/slop && sudo chown -R $( whoami ):$( whoami ) /opt/postgres/slop
   SLOP_DIR="/opt/postgres/slop"
   sudo $( which chown ) $USER:postgres /opt/postgres/slop
-  /usr/lib/postgresql/13/bin/pg_ctl initdb -D /opt/postgres/slop -l /opt/postgres/slop/main.log
+  /usr/lib/postgresql/$(ls */bin/pg_ctl) initdb -D /opt/postgres/slop -l /opt/postgres/slop/main.log
   sudo $( which chmod ) o+w /var/run/postgresql
   sudo $( which chown ) postgres:postgres /var/run/postgresql
-  /usr/lib/postgresql/13/bin/pg_ctl restart -D /opt/postgres/slop -l /opt/postgres/slop/main.log
+  /usr/lib/postgresql/$(ls */bin/pg_ctl) restart -D /opt/postgres/slop -l /opt/postgres/slop/main.log
   cd $SLOP_DIR && $(which createdb ) sloppy_bots -E utf-8 -O $( whoami ) -h localhost -p 5432
   echo "If any of these commands failed, you will need to re-run them yourself."
   echo "PG_SLOP=1" >> ~/.bashrc


### PR DESCRIPTION
this should work for all versions of postgresql.. you could also include an || statement and pipe in the commands from non-deb versions too assuming the rest of the code doesn't change tremendously.